### PR TITLE
Added waveshare29inch.py

### DIFF
--- a/pwnagotchi/ui/hw/waveshare29inch.py
+++ b/pwnagotchi/ui/hw/waveshare29inch.py
@@ -1,0 +1,47 @@
+import logging
+
+import pwnagotchi.ui.fonts as fonts
+from pwnagotchi.ui.hw.base import DisplayImpl
+
+
+class Waveshare29inch(DisplayImpl):
+    def __init__(self, config):
+        super(Waveshare29inch, self).__init__(config, 'waveshare_29inch')
+        self._display = None
+
+    def layout(self):
+        fonts.setup(10, 9, 10, 35)
+        self._layout['width'] = 296
+        self._layout['height'] = 128
+        self._layout['face'] = (0, 40)
+        self._layout['name'] = (5, 25)
+        self._layout['channel'] = (0, 0)
+        self._layout['aps'] = (28, 0)
+        self._layout['uptime'] = (230, 0)
+        self._layout['line1'] = [0, 14, 296, 14]
+        self._layout['line2'] = [0, 112, 296, 112]
+        self._layout['friend_face'] = (0, 96)
+        self._layout['friend_name'] = (40, 96)
+        self._layout['shakes'] = (0, 114)
+        self._layout['mode'] = (268, 114)
+        self._layout['status'] = {
+            'pos': (130, 25),
+            'font': fonts.Medium,
+            'max': 28
+        }
+        return self._layout
+
+    def initialize(self):
+        logging.info("initializing waveshare v1 2.9 inch display")
+        from pwnagotchi.ui.hw.libs.waveshare.v29inch.epd2in9 import EPD
+        self._display = EPD()
+        self._display.init(self._display.lut_full_update)
+        self._display.Clear(0xFF)
+        self._display.init(self._display.lut_partial_update)
+
+    def render(self, canvas):
+        buf = self._display.getbuffer(canvas)
+        self._display.display(buf)
+
+    def clear(self):
+        self._display.Clear(0xFF)


### PR DESCRIPTION
Added the Waveshare e-ink 2.9 inch display definition and layout.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Added the layout and definitions python file to allow Pwnagotchi to work correctly with the Waveshare 2.9 inch display.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Waveshare 2.9inch display was not originally included. Another user added the drivers, but the resolution and layout was incorrect.

- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested extensively on my own 2.9inch e-ink display on a Raspberry Pi Zero W.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
